### PR TITLE
Isaac/revert temporary fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ The base environment `legged_robot` constructs a rough terrain locomotion task. 
 3. If needed, create your environment in `<your_env>.py`. Inherit from existing environments, override desired functions and/or add your reward functions.
 4. Register your environment in `humanoid/envs/__init__.py`.
 5. Modify or tune other parameters in your `cfg` or `cfg_train` as per requirements. To remove the reward, set its scale to zero. Avoid modifying the parameters of other environments!
+6. If you want a new robot/environment to perform sim2sim, you may need to modify `humanoid/scripts/sim2sim.py`: 
+    - Check the joint mapping of the robot between MJCF and URDF.
+    - Change the initial joint position of the robot according to your trained policy.
 
 ## Troubleshooting
 

--- a/humanoid/envs/base/legged_robot.py
+++ b/humanoid/envs/base/legged_robot.py
@@ -452,7 +452,7 @@ class LeggedRobot(BaseTask):
         self.base_euler_xyz = get_euler_xyz_tensor(self.base_quat)
 
         self.contact_forces = gymtorch.wrap_tensor(net_contact_forces).view(self.num_envs, -1, 3) # shape: num_envs, num_bodies, xyz axis
-        self.rigid_state = gymtorch.wrap_tensor(rigid_body_state).view(self.num_envs, 13, 13)
+        self.rigid_state = gymtorch.wrap_tensor(rigid_body_state).view(self.num_envs, -1, 13)
 
         # initialize some data used later on
         self.common_step_counter = 0

--- a/humanoid/envs/base/legged_robot.py
+++ b/humanoid/envs/base/legged_robot.py
@@ -746,16 +746,15 @@ class LeggedRobot(BaseTask):
             self.gym.set_actor_dof_properties(env_handle, actor_handle, dof_props)
             body_props = self.gym.get_actor_rigid_body_properties(env_handle, actor_handle)
             body_props = self._process_rigid_body_props(body_props, i)
-
             # FIXME: (is2ac) temporary hack to fix the mass of the robot
-            for j, prop in enumerate(body_props):
-                if abs(prop.mass) > 1e-5:
-                    prop.mass = 1e-7
-                prop.mass = prop.mass * 1e7
+            # for j, prop in enumerate(body_props):
+            #     if abs(prop.mass) > 1e-5:
+            #         prop.mass = 1e-7
+            #     prop.mass = 1e-7
+            #     prop.mass = prop.mass * 1e7
             # FIXME
 
-            self.gym.set_actor_rigid_body_properties(env_handle, actor_handle, body_props, recomputeInertia=True)
-
+            self.gym.set_actor_rigid_body_properties(env_handle, actor_handle, body_props, recomputeInertia=False)
             self.envs.append(env_handle)
             self.actor_handles.append(actor_handle)
 
@@ -770,6 +769,7 @@ class LeggedRobot(BaseTask):
             print(f"  Body {j} mass: {prop.mass}")
             # prop.mass = prop.mass * 1e7
             print(f" Body {j} inertia: {prop.inertia.x}, {prop.inertia.y}, {prop.inertia.z}")
+            # For prop.inertia.x
 
         self.knee_indices = torch.zeros(len(knee_names), dtype=torch.long, device=self.device, requires_grad=False)
         for i in range(len(knee_names)):


### PR DESCRIPTION
Revert temporary fix to masses/inertias

The previous pr created fake values of masses for stompy, but now we are uploading real masses and inertias so there is no need for this.